### PR TITLE
Prepare for usage in FireFox

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -84,7 +84,10 @@
 		}
 	},
 	"content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
-	"options_page": "options.html",
+	"options_ui": {
+		"page": "options.html",
+		"open_in_tab": true
+	},
 	"permissions": [
 		"clipboardWrite",
 		"tts",


### PR DESCRIPTION
The extension works fine in FireFox. The options page does not show and there are some warnings about the tts permission (Text To Speech) which is not available in FireFox. 

Otherwise it works fine. The notation for the options page works on both Chrome and FireFox.

You should be able to publish this extension for FireFox now.

If you want to test this locally you will need to set a temporary addon ID because the storage api will fail otherwise and styles will be unavailable.

Add something like this to the manifest for testing, but don't commit ( what you put in the id field does not matter )

```
  "browser_specific_settings": {
    "gecko": {
      "id": "a86c1dbc39364b83892c6eb4fe50bff9aacad4c6@temp",
      "strict_min_version": "42.0"
    }
  },
```